### PR TITLE
Implement trivial version of static code rewriter

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
       "ts-node/register"
     ]
   },
-  "dependencies": {},
+  "dependencies": {
+    "babel-code-frame": "^6.16.0"
+  },
   "devDependencies": {
     "@types/babel-core": "^6.7.14",
     "@types/babel-traverse": "^6.7.14",
@@ -32,6 +34,7 @@
     "@types/mocha": "^2.2.32",
     "@types/node": "^6.0.41",
     "@types/sinon": "^1.16.31",
+    "@types/sinon-chai": "^2.7.27",
     "@types/source-map": "^0.1.27",
     "babel-core": "^6.16.0",
     "chai": "^3.5.0",
@@ -40,6 +43,7 @@
     "mocha": "^3.1.0",
     "nyc": "^8.3.0",
     "sinon": "^1.17.6",
+    "sinon-chai": "^2.8.0",
     "ts-node": "^1.3.0",
     "tslint": "^3.15.1",
     "typescript": "^2.0.3"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * The name of the parallel es npm module
+ * @type {string}
+ */
+export const PARALLEL_ES_MODULE_NAME = "parallel-es";

--- a/src/function-registration.ts
+++ b/src/function-registration.ts
@@ -1,7 +1,5 @@
 import * as t from "babel-types";
 
-export type FunctionNode = t.FunctionExpression | t.FunctionDeclaration | t.ArrowFunctionExpression;
-
 /**
  * The registration of a single functor
  */
@@ -14,5 +12,5 @@ export interface IFunctorRegistration {
     /**
      * The node defining the functor
      */
-    readonly node: FunctionNode;
+    readonly node: t.Function;
 }

--- a/src/module-functions-registry.ts
+++ b/src/module-functions-registry.ts
@@ -1,5 +1,6 @@
+import * as t from "babel-types";
 import {NodePath} from "babel-traverse";
-import {IFunctorRegistration, FunctionNode} from "./function-registration";
+import {IFunctorRegistration} from "./function-registration";
 import {RawSourceMap} from "source-map";
 
 /**
@@ -24,7 +25,7 @@ export class ModuleFunctionsRegistry {
         return this.functionsRegistry.size === 0;
     }
 
-    constructor(public fileName: string, public code: string, public map?: RawSourceMap) {
+    constructor(public fileName: string, public map?: RawSourceMap) {
     }
 
     /**
@@ -32,7 +33,7 @@ export class ModuleFunctionsRegistry {
      * @param path the path of the function
      * @returns the created registration
      */
-    public registerFunction(path: NodePath<FunctionNode>): IFunctorRegistration {
+    public registerFunction(path: NodePath<t.Function>): IFunctorRegistration {
         path.assertFunction();
 
         const key = path.getPathLocation();

--- a/src/parallel-functors-extractor-visitor.ts
+++ b/src/parallel-functors-extractor-visitor.ts
@@ -2,109 +2,7 @@ import * as t from "babel-types";
 import {NodePath, Visitor} from "babel-traverse";
 import {ModuleFunctionsRegistry} from "./module-functions-registry";
 import {ModulesUsingParallelRegistry} from "./modules-using-parallel-registry";
-
-const PARALLEL_MODULE_NAME = "parallel-es";
-
-function getParallelObject(path: NodePath<any>): NodePath<t.Identifier> | undefined {
-    if (path.getData("parallelObject")) {
-        return path.getData("parallelObject");
-    }
-
-    if (path.isIdentifier()) {
-        //  todo store parallel flag on identifier to avoid lookup
-        const binding = path.scope.getBinding(path.node.name);
-
-        if (binding) {
-            // import parallel from ...
-            if (binding.path.isImportDefaultSpecifier()) {
-                const importStatement = binding.path.parent as t.ImportDeclaration;
-
-                if (importStatement.source.value === PARALLEL_MODULE_NAME) {
-                    return binding.path.get("identifier") as NodePath<t.Identifier>;
-                }
-            } else if (t.isImportSpecifier(binding.path.node) && (binding.path.parent as t.ImportDeclaration).source.value === PARALLEL_MODULE_NAME && binding.path.node.imported.name === "default") {
-                  return binding.path.get("local") as NodePath<t.Identifier>;
-            } else if (t.isVariableDeclarator(binding.path.node) && t.isCallExpression(binding.path.node.init) && binding.path.node.init.arguments.length > 0) {
-                // require js const parallel = require('parallel...');
-
-                const requireCall = binding.path.node.init;
-                if (t.isIdentifier(requireCall.callee) && requireCall.callee.name === "require" && t.isStringLiteral(requireCall.arguments[0]) && (requireCall.arguments[0] as t.StringLiteral).value === PARALLEL_MODULE_NAME) {
-                    return binding.path.get("id") as NodePath<t.Identifier>;
-                }
-            }
-        }
-    }
-
-    if (path.isCallExpression() && t.isMemberExpression(path.node.callee)) {
-        const chain = path.get("callee.object");
-        return getParallelObject(chain);
-    }
-
-    return undefined;
-}
-
-function isParallelObject(object: NodePath<any>): boolean {
-    return !!getParallelObject(object);
-}
-
-function getParallelMethodName(path: NodePath<t.MemberExpression>): string | undefined {
-    path.assertMemberExpression();
-
-    if (t.isIdentifier(path.node.property)) {
-        return path.node.property.name;
-    }
-
-    return undefined;
-}
-
-const StatefulVisitor: Visitor = {
-    CallExpression:  {
-        enter(path: NodePath<t.CallExpression>) {
-            if (t.isMemberExpression(path.node.callee) && isParallelObject(path.get("callee.object"))) {
-                path.setData("parallelChain", path.get("callee.object"));
-            }
-        },
-
-        exit(path: NodePath<t.CallExpression>, moduleFunctionRegistry: ModuleFunctionsRegistry) {
-            if (!t.isMemberExpression(path.node.callee) || !isParallelObject(path.get("callee.object"))) {
-                return;
-            }
-
-            const methodName = getParallelMethodName(path.get("callee") as NodePath<t.MemberExpression>);
-
-            if (!methodName) {
-                return;
-            }
-
-            path.debug(() => `Found invocation of parallel method ${methodName}`);
-
-            if (methodName === "map") {
-                const mapper: NodePath<t.Node> | undefined = path.node.arguments.length > 0 ? path.get("arguments.0") : undefined;
-                if (mapper) {
-                    let mapperDeclaration: NodePath<t.FunctionDeclaration | t.ArrowFunctionExpression | t.FunctionExpression>;
-                    if (t.isIdentifier(mapper.node)) {
-                        const binding = path.scope.getBinding(mapper.node.name);
-                        // TODO handle case where this might be an identifier referencing a function expression or arrow expression or another variable or what ever.
-                        binding.path.assertFunctionDeclaration();
-
-                        mapperDeclaration = binding.path as NodePath<t.FunctionDeclaration>;
-                    } else if (t.isFunctionExpression(mapper.node) || t.isArrowFunctionExpression(mapper.node)) {
-                        mapperDeclaration = mapper as NodePath<t.FunctionExpression | t.ArrowFunctionExpression>;
-                    } else {
-                        throw new Error("unknown mapper function type");
-                    }
-
-                    const registration = moduleFunctionRegistry.registerFunction(mapperDeclaration);
-
-                    mapper.replaceWith(t.objectExpression([
-                        t.objectProperty(t.identifier("identifier"), t.stringLiteral(registration.identifier)),
-                        t.objectProperty(t.identifier("_______isFunctionId"), t.booleanLiteral(true))
-                    ]));
-                }
-            }
-        }
-    }
-};
+import {StatefulParallelFunctorsExtractorVisitor} from "./stateful-parallel-functors-extractor-visitor";
 
 /**
  * Creates a new babel-plugin that extract all functors passed to parallel.* and registers them in the passed in registry
@@ -119,11 +17,11 @@ export function ParallelFunctorsExtractorVisitor (modulesUsingParallelRegistry: 
             // to source map containing exactly this state!
             const map = Object.assign({}, path.hub.file.opts.inputSourceMap);
             const filename = path.hub.file.opts.filename;
-            const moduleFunctionRegistry = new ModuleFunctionsRegistry(filename, path.hub.file.code, map);
+            const moduleFunctionRegistry = new ModuleFunctionsRegistry(filename, map);
 
             modulesUsingParallelRegistry.remove(filename);
 
-            path.traverse(StatefulVisitor, moduleFunctionRegistry);
+            path.traverse(StatefulParallelFunctorsExtractorVisitor, moduleFunctionRegistry);
             if (!moduleFunctionRegistry.empty) {
                 modulesUsingParallelRegistry.add(moduleFunctionRegistry);
             }

--- a/src/stateful-parallel-functors-extractor-visitor.ts
+++ b/src/stateful-parallel-functors-extractor-visitor.ts
@@ -1,0 +1,185 @@
+import * as t from "babel-types";
+import {NodePath, Visitor} from "babel-traverse";
+import {ModuleFunctionsRegistry} from "./module-functions-registry";
+import {PARALLEL_ES_MODULE_NAME} from "./constants";
+import {warn} from "./util";
+import {IFunctorRegistration} from "./function-registration";
+
+function isParallelObject(path: NodePath<any>): boolean {
+    const parallel = path.getData("parallel:instance");
+
+    if (parallel) {
+        return true;
+    }
+
+    if (t.isIdentifier(path.node)) {
+        const binding = path.scope.getBinding(path.node.name);
+
+        if (binding) {
+            return !!binding.path.getData("parallel:instance");
+        }
+    } else if (t.isCallExpression(path.node)) {
+        return isParallelObject(path.get("callee"));
+    } else if (t.isMemberExpression(path.node)) {
+        return isParallelObject(path.get("object"));
+    }
+
+    return false;
+}
+
+function getParallelMethodName(path: NodePath<t.MemberExpression>): string | undefined | never {
+    path.assertMemberExpression();
+
+    if (!isParallelObject(path)) {
+        return undefined;
+    }
+
+    if (t.isIdentifier(path.node.property)) {
+        return path.node.property.name;
+    }
+
+    throw path.buildCodeFrameError("don't know how to determine the parallel method name from the given node", Error);
+}
+
+function hasProperty(object: NodePath<t.ObjectExpression>, propertyName: string): boolean {
+    for (let i = 0; i < object.node.properties.length; ++i) {
+        const property = object.get(`properties.${i}`);
+        const key = property.toComputedKey();
+
+        if (key && t.isStringLiteral(key) && key.value === propertyName) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Resolves the function declaration referenced by the given path. If the path itself is a function expression, declaration or
+ * arrow function expression, then the path itself is returned. If the path is an identifier, then it is tried to resolve the binding.
+ * @param functionPath the path that should reference a function
+ * @param allowNonFunctions indicator if the method should fail if a non function argument has been identified
+ * @returns path referencing a function, an object expression if it is a serialized function id or undefined if the function failed to resolve the
+ * reference
+ * @throws if the path is neither a serialized function id, reference nor function and {@code allowNonFunctions} is not true
+ */
+function resolveFunction(functionPath: NodePath<t.Node>, allowNonFunctions: boolean = false): NodePath<t.Node> | undefined {
+    const resolved = functionPath.resolve(false);
+
+    if (t.isFunction(resolved.node)) {
+        return resolved as NodePath<t.Function>;
+    }
+
+    // serialized function id
+    if (t.isObjectExpression(resolved.node)  && hasProperty(resolved as NodePath<t.ObjectExpression>, "_______isFunctionId")) {
+        return resolved as NodePath<t.ObjectExpression>;
+    }
+
+    if (t.isIdentifier(resolved.node)) {
+        warn(functionPath, `The function identified by the given node could not be identified. Static code rewriting of the function is therefore not possible, dynamic function dispatching is used instead.`);
+        return undefined;
+    }
+
+    if (!allowNonFunctions) {
+        throw functionPath.buildCodeFrameError("The node passed as functor is neither a serialized function nor a reference to a function. Invalid use of the api.");
+    }
+
+    return undefined;
+}
+
+const METHODS: { [name: string]: { functorIndex: number, allowNonFunctions?: boolean, functionCall?: boolean }} = {
+    filter: { functorIndex: 0 },
+    inEnvironment: { allowNonFunctions: true, functionCall: true, functorIndex: 0 },
+    map: { functorIndex: 0 },
+    reduce: { functorIndex: 1 },
+    schedule: { allowNonFunctions: true, functionCall: true, functorIndex: 0},
+    times: { allowNonFunctions: true, functorIndex: 1 }
+};
+
+function createFunctionId(registration: IFunctorRegistration) {
+    return t.objectExpression([
+        t.objectProperty(t.identifier("identifier"), t.stringLiteral(registration.identifier)),
+        t.objectProperty(t.identifier("_______isFunctionId"), t.booleanLiteral(true))
+    ]);
+}
+
+function createSerializedFunctionCall(functionId: t.ObjectExpression, parameters: Array<t.Expression | t.SpreadElement>) {
+    return t.objectExpression([
+        t.objectProperty(t.identifier("functionId"), functionId),
+        t.objectProperty(t.identifier("parameters"), t.arrayExpression(parameters)),
+        t.objectProperty(t.identifier("______serializedFunctionCall"), t.booleanLiteral(true))
+    ]);
+}
+
+export const StatefulParallelFunctorsExtractorVisitor: Visitor = {
+    /**
+     * Extracts the parallel identifier for an import default node
+     */
+    ImportDefaultSpecifier(path: NodePath<t.ImportDefaultSpecifier>) {
+        const importStatement = path.parent as t.ImportDeclaration;
+
+        if (importStatement.source.value === PARALLEL_ES_MODULE_NAME) {
+            path.setData("parallel:instance", true);
+        }
+    },
+
+    /**
+     * Extracts the parallel identifier for a named default import
+     */
+    ImportSpecifier(path: NodePath<t.ImportSpecifier>) {
+        const importStatement = path.parent as t.ImportDeclaration;
+
+        if (importStatement.source.value === PARALLEL_ES_MODULE_NAME && path.node.imported.name === "default") {
+            path.setData("parallel:instance", true);
+        }
+    },
+
+    VariableDeclarator(path: NodePath<t.VariableDeclarator>) {
+        // Is it a require call?
+        if (t.isCallExpression(path.node.init) && t.isIdentifier(path.node.init.callee) && path.node.init.arguments.length === 1) {
+            const callee = path.node.init.callee;
+            const functionCall: t.CallExpression = path.node.init;
+            const firstArgument = t.isStringLiteral(functionCall.arguments[0]) ? functionCall.arguments[0] as t.StringLiteral : undefined;
+            if (callee.name === "require" && firstArgument && firstArgument.value === PARALLEL_ES_MODULE_NAME) {
+                path.setData("parallel:instance", true);
+            }
+        }
+    },
+
+    CallExpression(path: NodePath<t.CallExpression>, moduleFunctionRegistry: ModuleFunctionsRegistry) {
+        if (!t.isMemberExpression(path.node.callee)) {
+            return;
+        }
+
+        const methodName = getParallelMethodName(path.get("callee") as NodePath<t.MemberExpression>);
+
+        if (!methodName || !METHODS.hasOwnProperty(methodName)) {
+            return;
+        }
+
+        path.debug(() => `Found invocation of parallel method ${methodName}`);
+
+        const method = METHODS[methodName];
+        if (path.node.arguments.length > method.functorIndex) {
+            const functor = path.get(`arguments.${method.functorIndex}`) as NodePath<t.Expression | t.SpreadElement>;
+            let functorDeclaration = resolveFunction(functor, method.allowNonFunctions);
+            if (functorDeclaration && functorDeclaration.isFunction()) {
+                const registration = moduleFunctionRegistry.registerFunction(functorDeclaration! as NodePath<t.Function>);
+                const functionId = createFunctionId(registration);
+
+                if (method.functionCall) {
+                    const parameters = ((path.get("arguments") as any) as NodePath<t.Expression | t.SpreadElement>[]).slice(method.functorIndex + 1);
+                    const functionCall = createSerializedFunctionCall(functionId, parameters.map(parameter => parameter.node));
+                    parameters.forEach(parameter => parameter.remove());
+                    functor.replaceWith(functionCall);
+                } else {
+                    if (methodName === "reduce" && path.node.arguments.length < 3) {
+                        path.node.arguments.push(functor.node);
+                    }
+
+                    functor.replaceWith(functionId);
+                }
+            }
+        }
+    }
+};

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,8 @@
+import codeFrame = require("babel-code-frame");
+import * as t from "babel-types";
+import {NodePath} from "babel-traverse";
+
+export function warn(path: NodePath<t.Node>, message: string) {
+    message += "\n" + codeFrame(path.hub.file.code, path.node.loc.start.line, path.node.loc.start.column);
+    path.hub.file.log.warn(message);
+}

--- a/test/module-function-registry.specs.ts
+++ b/test/module-function-registry.specs.ts
@@ -8,17 +8,12 @@ describe("ModuleFunctionRegistry", function () {
     let registry: ModuleFunctionsRegistry;
 
     beforeEach(function () {
-        registry = new ModuleFunctionsRegistry("test.js", "const x = 10;");
+        registry = new ModuleFunctionsRegistry("test.js");
     });
 
     it("has the module name passed in the constructor", function () {
         // assert
         expect(registry.fileName).to.equal("test.js");
-    });
-
-    it("has the code passed in the constructor", function () {
-        // assert
-        expect(registry.code).to.equal("const x = 10;");
     });
 
     it("has no source map by default", function () {
@@ -31,7 +26,7 @@ describe("ModuleFunctionRegistry", function () {
         const sourceMap = {} as any;
 
         // act
-        registry = new ModuleFunctionsRegistry("test.js", "const x = 10;", sourceMap);
+        registry = new ModuleFunctionsRegistry("test.js", sourceMap);
 
         // assert
         expect(registry.map).to.equal(sourceMap);

--- a/test/modules-using-parallel-registry.specs.ts
+++ b/test/modules-using-parallel-registry.specs.ts
@@ -22,8 +22,8 @@ describe("ModulesUsingParallelRegistry", function () {
 
         it("returns an array containing the registered modules", function () {
             // arrange
-            const firstModule = new ModuleFunctionsRegistry("test.js", "const x = 10;");
-            const secondModule = new ModuleFunctionsRegistry("second.js", "require('./test.js');");
+            const firstModule = new ModuleFunctionsRegistry("test.js");
+            const secondModule = new ModuleFunctionsRegistry("second.js");
 
             registry.add(firstModule);
             registry.add(secondModule);
@@ -36,7 +36,7 @@ describe("ModulesUsingParallelRegistry", function () {
     describe("add", function () {
         it("registers the module", function () {
             // arrange
-            const module = new ModuleFunctionsRegistry("test.js", "const x = 10;");
+            const module = new ModuleFunctionsRegistry("test.js");
 
             // act
             registry.add(module);
@@ -47,7 +47,7 @@ describe("ModulesUsingParallelRegistry", function () {
 
         it("freezes the module", function () {
             // arrange
-            const module = new ModuleFunctionsRegistry("test.js", "const x = 10;");
+            const module = new ModuleFunctionsRegistry("test.js");
 
             // act
             registry.add(module);
@@ -58,7 +58,7 @@ describe("ModulesUsingParallelRegistry", function () {
 
         it("increases the version", function () {
             // arrange
-            const module = new ModuleFunctionsRegistry("test.js", "const x = 10;");
+            const module = new ModuleFunctionsRegistry("test.js");
 
             // act
             registry.add(module);
@@ -74,8 +74,8 @@ describe("ModulesUsingParallelRegistry", function () {
 
         beforeEach(function () {
             // arrange
-            testModule = new ModuleFunctionsRegistry("test.js", "const x = 10;");
-            secondModule = new ModuleFunctionsRegistry("second.js", "require('./test.js');");
+            testModule = new ModuleFunctionsRegistry("test.js");
+            secondModule = new ModuleFunctionsRegistry("second.js");
 
             registry.add(testModule);
             registry.add(secondModule);
@@ -111,7 +111,7 @@ describe("ModulesUsingParallelRegistry", function () {
 
         beforeEach(function () {
             // arrange
-            testModule = new ModuleFunctionsRegistry("test.js", "const x = 10;");
+            testModule = new ModuleFunctionsRegistry("test.js");
 
             registry.add(testModule);
         });
@@ -130,7 +130,7 @@ describe("ModulesUsingParallelRegistry", function () {
 
         beforeEach(function () {
             // arrange
-            testModule = new ModuleFunctionsRegistry("test.js", "const x = 10;");
+            testModule = new ModuleFunctionsRegistry("test.js");
 
             registry.add(testModule);
         });

--- a/test/stateful-parallel-functors-extractor-visitor.specs.ts
+++ b/test/stateful-parallel-functors-extractor-visitor.specs.ts
@@ -1,0 +1,456 @@
+import {use as chaiUse, expect} from "chai";
+import * as sinon from "sinon";
+import * as sinonChai from "sinon-chai";
+
+import {transform} from "babel-core";
+import * as t from "babel-types";
+import {NodePath} from "babel-traverse";
+import * as util from "../src/util";
+import {PARALLEL_ES_MODULE_NAME} from "../src/constants";
+import {ModuleFunctionsRegistry} from "../src/module-functions-registry";
+import {StatefulParallelFunctorsExtractorVisitor} from "../src/stateful-parallel-functors-extractor-visitor";
+chaiUse(sinonChai);
+
+describe("StatefulParallelFunctorsExtractorVisitor", function () {
+    let moduleFunctionRegistry: ModuleFunctionsRegistry;
+    let registerFunctionSpy: sinon.SinonStub;
+    let warnSpy: sinon.SinonSpy;
+
+    beforeEach(function () {
+        moduleFunctionRegistry = new ModuleFunctionsRegistry("test.js");
+        registerFunctionSpy = sinon.stub(moduleFunctionRegistry, "registerFunction");
+        registerFunctionSpy.returns({
+            identifier: "static-id",
+            node: undefined
+        });
+        warnSpy = sinon.spy(util, "warn");
+    });
+
+    afterEach(function () {
+         registerFunctionSpy.restore();
+         warnSpy.restore();
+    });
+
+    describe("Imports", function () {
+        describe("Default Import", function () {
+            it("sets 'parallel:instance' to true for the bindings path of the default import parallel", function () {
+                const program = visit(`import parallel from "${PARALLEL_ES_MODULE_NAME}";`);
+
+                const binding = program.scope.getBinding("parallel");
+                expect(binding.path.getData("parallel:instance")).to.be.true;
+            });
+
+            it("sets 'parallel:instance' of the default parallel import path to true even if not named parallel", function () {
+                const program = visit(`import par from "${PARALLEL_ES_MODULE_NAME}";`);
+
+                const parallel = program.scope.getBinding("par");
+                expect(parallel.path.getData("parallel:instance")).to.be.true;
+            });
+
+            it("does not set 'parallel:instance' to true for a default import of another moduel", function () {
+                const program = visit(`import parallel from "other";`);
+
+                expect(program.scope.getBinding("parallel").path.getData("parallel:instance")).to.be.undefined;
+            });
+        });
+
+        describe("Named Default Import", function () {
+            it("sets 'parallel:instance' to true for the path of the binding for a named default import", function () {
+                const program = visit(`import {default as par} from "${PARALLEL_ES_MODULE_NAME}";`);
+
+                const parallelBinding = program.scope.getBinding("par");
+                expect(parallelBinding.path.getData("parallel:instance")).to.be.true;
+            });
+
+            it("doe snot set 'parallel:instance' to true if it is another named import", function () {
+                const program = visit(`import {IParallel} from "${PARALLEL_ES_MODULE_NAME}";`);
+
+                const binding = program.scope.getBinding("IParallel");
+                expect(binding.path.getData("parallel:instance")).to.be.undefined;
+            });
+
+            it("does not set the identifier if another module is imported", function () {
+                const program = visit(`import {default as test} from "other";`);
+
+                const binding = program.scope.getBinding("test");
+                expect(binding.path.getData("parallel:instance")).to.be.undefined;
+            });
+        });
+
+        describe("CommonJS", function () {
+            it("sets 'parallel:instance' to true for the binding of a variable bound to require('parallel-es')", function () {
+                const program = visit(`const parallel = require("${PARALLEL_ES_MODULE_NAME}");`);
+
+                const binding = program.scope.getBinding("parallel");
+                expect(binding.path.getData("parallel:instance")).to.be.true;
+            });
+
+            it("does not set 'parallel.instance' another module is required", function () {
+                const program = visit(`const parallel = require("par");`);
+
+                const binding = program.scope.getBinding("parallel");
+                expect(binding.path.getData("parallel:instance")).to.be.undefined;
+            });
+
+            it("does not set 'paralle.instance' if it is a constant variable", function () {
+                const program = visit(`const parallel = true;`);
+
+                const binding = program.scope.getBinding("parallel");
+                expect(binding.path.getData("parallel:instance")).to.be.undefined;
+            });
+        });
+    });
+
+    describe("Method Registration", function () {
+        describe("map", function () {
+            it("registers the mapper", function () {
+                const program = visit(`
+                import parallel from "${PARALLEL_ES_MODULE_NAME}";
+                parallel.from([1, 2, 3]).map(value => value * 2);
+                `);
+
+                const mapper = program.get("body.1.expression.arguments.0");
+                expect(registerFunctionSpy).to.have.been.calledWith(mapper);
+            });
+
+            it("replaces the mapper arrow expression with the function id", function () {
+                registerFunctionSpy.returnValue = {
+                    identifier: "unique-id",
+                    node: undefined as any
+                };
+
+                const program = visit(`
+                import parallel from "${PARALLEL_ES_MODULE_NAME}";
+                parallel.from([1, 2, 3]).map(value => value * 2);
+                `);
+
+                const mapper = program.get("body.1.expression.arguments.0");
+                expect(mapper.isObjectExpression()).to.be.true;
+
+                const functionId = mapper.node as t.ObjectExpression;
+                expect(functionId.properties).to.have.lengthOf(2);
+                expect(functionId.properties).to.have.deep.property("[0].key.name", "identifier");
+                expect(functionId.properties).to.have.deep.property("[0].value.value", "static-id");
+                expect(functionId.properties).to.have.deep.property("[1].key.name", "_______isFunctionId");
+                expect(functionId.properties).to.have.deep.property("[1].value.value", true);
+            });
+
+            it("replaces the mapper function expression with the function id", function () {
+                registerFunctionSpy.returnValue = {
+                    identifier: "unique-id",
+                    node: undefined as any
+                };
+
+                const program = visit(`
+                import parallel from "${PARALLEL_ES_MODULE_NAME}";
+                parallel.from([1, 2, 3]).map(function (value) { return value * 2; });
+                `);
+
+                const mapper = program.get("body.1.expression.arguments.0");
+                expect(mapper.isObjectExpression()).to.be.true;
+
+                const functionId = mapper.node as t.ObjectExpression;
+                expect(functionId.properties).to.have.lengthOf(2);
+                expect(functionId.properties).to.have.deep.property("[0].key.name", "identifier");
+                expect(functionId.properties).to.have.deep.property("[0].value.value", "static-id");
+                expect(functionId.properties).to.have.deep.property("[1].key.name", "_______isFunctionId");
+                expect(functionId.properties).to.have.deep.property("[1].value.value", true);
+            });
+
+            it("replaces the function reference with the function id", function () {
+                registerFunctionSpy.returnValue = {
+                    identifier: "unique-id",
+                    node: undefined as any
+                };
+
+                const program = visit(`
+                import parallel from "${PARALLEL_ES_MODULE_NAME}";
+                function duplicate(value) {
+                    return value + value;
+                }
+                
+                parallel.from([1, 2, 3]).map(duplicate);
+                `);
+
+                const mapper = program.get("body.2.expression.arguments.0");
+                expect(mapper.isObjectExpression()).to.be.true;
+
+                const functionId = mapper.node as t.ObjectExpression;
+                expect(functionId.properties).to.have.lengthOf(2);
+                expect(functionId.properties).to.have.deep.property("[0].key.name", "identifier");
+                expect(functionId.properties).to.have.deep.property("[0].value.value", "static-id");
+                expect(functionId.properties).to.have.deep.property("[1].key.name", "_______isFunctionId");
+                expect(functionId.properties).to.have.deep.property("[1].value.value", true);
+            });
+
+            it("registers the function referenced by the identifier", function () {
+                registerFunctionSpy.returnValue = {
+                    identifier: "unique-id",
+                    node: undefined as any
+                };
+
+                const program = visit(`
+                import parallel from "${PARALLEL_ES_MODULE_NAME}";
+                const duplicate = value => value + value;
+                
+                parallel.from([1, 2, 3]).map(duplicate);
+                `);
+
+                const mapper = program.get("body.1.declarations.0.init");
+                expect(registerFunctionSpy).to.have.been.calledWith(mapper);
+            });
+
+            it("supports aliasing", function () {
+                registerFunctionSpy.returnValue = {
+                    identifier: "unique-id",
+                    node: undefined as any
+                };
+
+                const program = visit(`
+                import parallel from "${PARALLEL_ES_MODULE_NAME}";
+                const duplicate = value => value + value;
+                const twice = duplicate;
+                
+                parallel.from([1, 2, 3]).map(twice);
+                `);
+
+                const mapper = program.get("body.1.declarations.0.init");
+                expect(registerFunctionSpy).to.have.been.calledWith(mapper);
+            });
+
+            it("logs a warning if the declaration of the passed functor cannot be identified", function () {
+                registerFunctionSpy.returnValue = {
+                    identifier: "unique-id",
+                    node: undefined as any
+                };
+
+                const program = visit(`
+                import parallel from "${PARALLEL_ES_MODULE_NAME}";
+                
+                function compute(operation) {
+                    return parallel.from([1, 2, 3]).map(operation);
+                }
+                
+                compute(() => value * 2);
+                `);
+
+                const mapper = program.get("body.1.body.body.0.argument.arguments.0");
+                expect(registerFunctionSpy).not.to.have.been.called;
+                expect(warnSpy).to.have.been.calledWith(mapper, "The function identified by the given node could not be identified. Static code rewriting of the function is therefore not possible, dynamic function dispatching is used instead.");
+            });
+
+            it("throws an error if the functor is not a function", function () {
+                expect(() => {
+                    visit(`
+                    import parallel from "${PARALLEL_ES_MODULE_NAME}";
+                    parallel.from([1, 2, 3]).map({ test: true });
+                    `);
+                }).to.throw("test.js: The node passed as functor is neither a serialized function nor a reference to a function. Invalid use of the api.");
+            });
+
+            it("does not register the functor if it is a serialized function id", function () {
+                visit(`
+                import parallel from "${PARALLEL_ES_MODULE_NAME}";
+                
+                parallel.from([1, 2, 3]).map({ _______isFunctionId: true, identifier: 'test' });
+                `);
+
+                expect(registerFunctionSpy).not.to.have.been.called;
+            });
+        });
+
+        describe("filter", function () {
+            it("registers the predicate", function () {
+                const program = visit(`
+                import parallel from "${PARALLEL_ES_MODULE_NAME}";
+                parallel.from([1, 2, 3]).filter(value => value % 2 === 0);
+                `);
+
+                const predicate = program.get("body.1.expression.arguments.0");
+                expect(registerFunctionSpy).to.have.been.calledWith(predicate);
+            });
+        });
+
+        describe("reduce", function () {
+            it("registers the accumulator", function () {
+                const program = visit(`
+                import parallel from "${PARALLEL_ES_MODULE_NAME}";
+                parallel.from([1, 2, 3]).reduce(0, (memo, value) => memo + value);
+                `);
+
+                const accumulator = program.get("body.1.expression.arguments.1");
+                expect(registerFunctionSpy).to.have.been.calledWith(accumulator);
+            });
+
+            it("adds the accumulator as combiner if reduce is only called with two arguments", function () {
+                const program = visit(`
+                import parallel from "${PARALLEL_ES_MODULE_NAME}";
+                parallel.from([1, 2, 3]).reduce(0, (memo, value) => memo + value);
+                `);
+
+                const accumulator = program.get("body.1.expression.arguments.2");
+                expect(accumulator.isArrowFunctionExpression()).to.be.true;
+            });
+
+            it("does not add the combiner if reduce is called with three arguments", function () {
+                const program = visit(`
+                import parallel from "${PARALLEL_ES_MODULE_NAME}";
+                let combiner = (memo, value) => value + memo;
+                parallel.from([1, 2, 3]).reduce(0, (memo, value) => memo + value, combiner);
+                `);
+
+                const accumulator = program.get("body.2.expression.arguments.2");
+                expect(accumulator.isIdentifier()).to.be.true;
+            });
+        });
+
+        describe("inEnvironment", function () {
+            it("registers the provider function", function () {
+                const program = visit(`
+                import parallel from "${PARALLEL_ES_MODULE_NAME}";
+                parallel.times(100, i => i**i).inEnvironment(() => ({ test: true }));
+                `);
+
+                const generator = program.get("body.1.expression.arguments.0");
+                expect(registerFunctionSpy).to.have.been.calledWith(generator);
+            });
+
+            it("replaces the provider function with a serialized function call", function () {
+                const program = visit(`
+                import parallel from "${PARALLEL_ES_MODULE_NAME}";
+                parallel.times(100, i => i**i).inEnvironment((arg1, arg2) => ({ test: true }), 10, 20);
+                `);
+
+                const inEnvironmentCall = program.get("body.1.expression") as NodePath<t.CallExpression>;
+                const generator = inEnvironmentCall.get("arguments.0");
+
+                expect(inEnvironmentCall.node.arguments).to.have.lengthOf(1);
+                expect(generator.isObjectExpression()).to.be.true;
+
+                const properties = (generator as NodePath<t.ObjectExpression>).node.properties;
+                expect(properties[0]).to.have.deep.property("key.name").that.equals("functionId");
+                expect(properties[0]).to.have.deep.property("value.properties[0].key.name").that.equals("identifier");
+                expect(properties[0]).to.have.deep.property("value.properties[0].value.value").that.equals("static-id");
+                expect(properties[0]).to.have.deep.property("value.properties[1].key.name").that.equals("_______isFunctionId");
+                expect(properties[0]).to.have.deep.property("value.properties[1].value.value").that.is.true;
+
+                expect(properties[1]).to.have.deep.property("key.name").that.equals("parameters");
+                expect(properties[1]).to.have.deep.property("value.elements[0].value").that.equals(10);
+                expect(properties[1]).to.have.deep.property("value.elements[1].value").that.equals(20);
+
+                expect(properties[2]).to.have.deep.property("key.name").that.equals("______serializedFunctionCall");
+                expect(properties[2]).to.have.deep.property("value.value").that.is.true;
+
+            });
+
+            it("also allows passing non functions instead of the functor", function () {
+                const program = visit(`
+                import parallel from "${PARALLEL_ES_MODULE_NAME}";
+                parallel.times(100, "start value").inEnvironment({ test: true });
+                `);
+
+                const environment = program.get("body.1.expression.arguments.0") as NodePath<t.ObjectExpression>;
+                expect(registerFunctionSpy).not.to.have.been.called;
+                expect(environment.node.properties[0]).to.have.deep.property("key.name").that.equals("test");
+            });
+        });
+
+        describe("times", function () {
+            it("registers the generator function", function () {
+                const program = visit(`
+                import parallel from "${PARALLEL_ES_MODULE_NAME}";
+                parallel.times(100, i => i**i);
+                `);
+
+                const generator = program.get("body.1.expression.arguments.1");
+                expect(registerFunctionSpy).to.have.been.calledWith(generator);
+            });
+
+            it("also allows passing non functions instead of the functor", function () {
+                visit(`
+                import parallel from "${PARALLEL_ES_MODULE_NAME}";
+                parallel.times(100, "start value");
+                `);
+
+                expect(registerFunctionSpy).not.to.have.been.called;
+            });
+        });
+
+        describe("schedule", function () {
+            it("registers the scheduled function", function () {
+                const program = visit(`
+                import parallel from "${PARALLEL_ES_MODULE_NAME}";
+                parallel.schedule(() => {
+                    for (let i = 0; i < 1000; ++i) {
+                        // heavy computation
+                    }
+                });
+                `);
+
+                const func = program.get("body.1.expression.arguments.0");
+                expect(registerFunctionSpy).to.have.been.calledWith(func);
+            });
+
+            it("replaces the function call with a serialized function call", function () {
+                const program = visit(`
+                import parallel from "${PARALLEL_ES_MODULE_NAME}";
+                parallel.schedule((arg1, arg2) => ({ test: true }), 10, 20);
+                `);
+
+                const scheduleCall = program.get("body.1.expression") as NodePath<t.CallExpression>;
+                const functor = scheduleCall.get("arguments.0");
+
+                expect(scheduleCall.node.arguments).to.have.lengthOf(1);
+                expect(functor.isObjectExpression()).to.be.true;
+
+                const properties = (functor as NodePath<t.ObjectExpression>).node.properties;
+                expect(properties[0]).to.have.deep.property("key.name").that.equals("functionId");
+                expect(properties[0]).to.have.deep.property("value.properties[0].key.name").that.equals("identifier");
+                expect(properties[0]).to.have.deep.property("value.properties[0].value.value").that.equals("static-id");
+                expect(properties[0]).to.have.deep.property("value.properties[1].key.name").that.equals("_______isFunctionId");
+                expect(properties[0]).to.have.deep.property("value.properties[1].value.value").that.is.true;
+
+                expect(properties[1]).to.have.deep.property("key.name").that.equals("parameters");
+                expect(properties[1]).to.have.deep.property("value.elements[0].value").that.equals(10);
+                expect(properties[1]).to.have.deep.property("value.elements[1].value").that.equals(20);
+
+                expect(properties[2]).to.have.deep.property("key.name").that.equals("______serializedFunctionCall");
+                expect(properties[2]).to.have.deep.property("value.value").that.is.true;
+            });
+        });
+
+        describe("not parallel", function () {
+            it("does not register functors passed to not parallel methods", function () {
+                visit(`
+                import parallel from "parallel2";
+                parallel.schedule(() => {
+                    for (let i = 0; i < 1000; ++i) {
+                        // heavy computation
+                    }
+                });
+                `);
+
+                expect(registerFunctionSpy).not.to.have.been.called;
+            });
+        });
+    });
+
+    function visit(code: string): NodePath<t.Program> {
+        let programPath: NodePath<t.Program> | undefined;
+        transform(code, {
+            filename: "test.js",
+            plugins: [
+                {
+                    visitor: {
+                        Program(path: NodePath<t.Program>) {
+                            programPath = path;
+                            path.traverse(StatefulParallelFunctorsExtractorVisitor, moduleFunctionRegistry);
+                        }
+                    }
+                }
+            ]
+        });
+
+        return programPath!;
+    }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "outDir": "dist",
     "target": "es5",
     "sourceMap": true,
-    "lib": ["es6"]
+    "lib": ["es6"],
+    "typeRoots": ["types", "node_modules/@types"]
   },
   "include": [
     "index.ts",

--- a/types/babel-code-frame/index.d.ts
+++ b/types/babel-code-frame/index.d.ts
@@ -1,0 +1,9 @@
+declare module "babel-code-frame" {
+    function codeFrame(rawLines: string, lineNumber: number, colNumber: number, options?: {
+        highlightCode?: boolean;
+        linesAbove?: number;
+        linesBelow?: number;
+    }): string;
+
+    export = codeFrame;
+}

--- a/types/babel-traverse/index.d.ts
+++ b/types/babel-traverse/index.d.ts
@@ -1,0 +1,15 @@
+/// <reference types="../../node_modules/@types/babel-traverse" />
+/// <reference types="../../node_modules/@types/babel-types" />
+
+import * as t from 'babel-types';
+
+declare module "babel-traverse" {
+    export interface NodePath<T> {
+        resolve(dangerous?: boolean): NodePath<t.Node>;
+        toComputedKey(): t.Node | undefined;
+        /**
+         * Fix for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/11654
+         */
+        buildCodeFrameError<TError extends Error>(msg: string, Error?: new (msg: string) => TError): TError;
+    }
+}


### PR DESCRIPTION
The current implementation only extracts the functions and passes serialized function ids or serialized function calls to the parallel facade.
Has support for source maps. But not for rewriting the environment or giving access to any imports.
