### PR TITLE
Add support for ES6 Modules

### DIFF
--- a/src/function-extractor/imports-registry.ts
+++ b/src/function-extractor/imports-registry.ts
@@ -1,0 +1,56 @@
+import {NodePath} from "babel-traverse";
+import * as t from "babel-types";
+
+export interface IImports {
+    [name: string]: IImport[];
+}
+
+export interface IImport {
+    imported: string;
+    local: string;
+    references: NodePath<t.Node>[];
+}
+
+export class ImportsRegistry {
+    private registeredImports = new Map<string, Map<string, IImport>>();
+
+    public addImport(module: string, imported: string, local: string, referencedIn: NodePath<t.Node>): void {
+        const moduleImports = this.getModuleImports(module);
+
+        const key = `${imported}:${local}`;
+        const importSpecifier = moduleImports.get(key);
+
+        if (importSpecifier) {
+            importSpecifier.references.push(referencedIn);
+        } else {
+            moduleImports.set(key, { imported, local, references: [referencedIn] });
+        }
+    }
+
+    public addDefaultImport(module: string, local: string, referencedIn: NodePath<t.Node>) {
+        this.addImport(module, "default", local, referencedIn);
+    }
+
+    public addNamespaceImport(module: string, local: string, referencedIn: NodePath<t.Node>) {
+        this.addImport(module, "*", local, referencedIn);
+    }
+
+    public getImports(): IImports {
+        const imports: IImports = {};
+        for (const module of Array.from(this.registeredImports.keys())) {
+            imports[module] = Array.from(this.getModuleImports(module).values());
+        }
+
+        return imports;
+    }
+
+    private getModuleImports(module: string): Map<string, IImport> {
+        let moduleImports = this.registeredImports.get(module);
+
+        if (!moduleImports) {
+            moduleImports = new Map<string, IImport>();
+            this.registeredImports.set(module, moduleImports);
+        }
+        return moduleImports;
+    }
+}

--- a/src/function-extractor/module-functions-registry.ts
+++ b/src/function-extractor/module-functions-registry.ts
@@ -2,13 +2,15 @@ import * as t from "babel-types";
 import {NodePath} from "babel-traverse";
 import {IFunctorRegistration} from "../function-registration";
 import {RawSourceMap} from "source-map";
+import {ImportsRegistry} from "./imports-registry";
 
 /**
  * Registry that stores the functions for a single module
  */
 export class ModuleFunctionsRegistry {
-    private functionsRegistry = new Map<string, IFunctorRegistration>();
+    public imports = new ImportsRegistry();
 
+    private functionsRegistry = new Map<string, IFunctorRegistration>();
     /**
      * Returns the functors passed to parallel
      * @returns the functors

--- a/src/function-extractor/stateful-parallel-functors-extractor-visitor.ts
+++ b/src/function-extractor/stateful-parallel-functors-extractor-visitor.ts
@@ -3,6 +3,7 @@ import {NodePath, Visitor} from "babel-traverse";
 import {ModuleFunctionsRegistry} from "./module-functions-registry";
 import {PARALLEL_ES_MODULE_NAME} from "../constants";
 import {warn, createFunctionId, createSerializedFunctionCall} from "../util";
+import {transpileFunctor} from "./transpile-functor";
 
 function isParallelObject(path: NodePath<any>): boolean {
     const parallel = path.getData("parallel:instance");
@@ -148,6 +149,8 @@ export const StatefulParallelFunctorsExtractorVisitor: Visitor = {
             const functor = path.get(`arguments.${method.functorIndex}`) as NodePath<t.Expression | t.SpreadElement>;
             let functorDeclaration = resolveFunction(functor, method.allowNonFunctions);
             if (functorDeclaration && functorDeclaration.isFunction()) {
+                transpileFunctor(functorDeclaration as NodePath<t.Function>, moduleFunctionRegistry);
+
                 const registration = moduleFunctionRegistry.registerFunction(functorDeclaration! as NodePath<t.Function>);
                 const functionId = createFunctionId(registration);
 

--- a/src/function-extractor/transpile-functor.ts
+++ b/src/function-extractor/transpile-functor.ts
@@ -1,0 +1,61 @@
+import {NodePath, Binding} from "babel-traverse";
+import * as t from "babel-types";
+import {ModuleFunctionsRegistry} from "./module-functions-registry";
+
+function registerImport(binding: Binding, moduleFunctionsRegistry: ModuleFunctionsRegistry, functor: NodePath<t.Function>) {
+    binding.path.parentPath.assertImportDeclaration();
+
+    const importNode = binding.path.node as t.ImportDefaultSpecifier | t.ImportNamespaceSpecifier | t.ImportSpecifier;
+    const importDeclaration = binding.path.parent as t.ImportDeclaration;
+    const source = binding.path.hub.file.resolveModuleSource(importDeclaration.source.value) as string;
+
+    if (t.isImportDefaultSpecifier(importNode)) {
+        moduleFunctionsRegistry.imports.addDefaultImport(source, importNode.local.name, functor);
+    } else if (t.isImportNamespaceSpecifier(importNode)) {
+        moduleFunctionsRegistry.imports.addNamespaceImport(source, importNode.local.name, functor);
+    } else if (t.isImportSpecifier(importNode)) {
+        moduleFunctionsRegistry.imports.addImport(source, importNode.imported.name, importNode.local.name, functor);
+    } else {
+        throw binding.path.buildCodeFrameError("Unknown import type");
+    }
+}
+
+interface IRewriterVisitorState {
+    module: ModuleFunctionsRegistry;
+    functor: NodePath<t.Function>;
+}
+
+function resolveInFunctorScope(name: string, start: NodePath<t.Node>, functor: NodePath<t.Function>): Binding | undefined {
+    /* tslint:disable:no-conditional-assignment */
+    let scope = start.scope;
+    let binding: Binding | undefined = undefined;
+    do {
+        binding = scope.getOwnBinding(name);
+    } while (!binding && ((scope = scope.parent) !== functor.scope.parent));
+
+    return binding;
+}
+
+const RewriterVisitor = {
+    ReferencedIdentifier(path: NodePath<t.Identifier>, state: IRewriterVisitorState) {
+        const localBinding = resolveInFunctorScope(path.node.name, path, state.functor);
+
+        if (!localBinding) {
+            // it is a binding that is defined outside of the functor, therefore the rewriter must make it available somehow...
+            // if there is no rule that can make it available, bark!
+            const binding = path.scope.getBinding(path.node.name);
+
+            if (!binding) {
+                return; // Globally defined objects like Math
+            } else if ((binding.kind as string) === "module") {
+                registerImport(binding, state.module, state.functor);
+            } else {
+                throw path.buildCodeFrameError("Access to identifier that is not bound inside of the functor");
+            }
+        }
+    }
+};
+
+export function transpileFunctor(functor: NodePath<t.Function>, moduleFunctionRegistry: ModuleFunctionsRegistry) {
+    return functor.traverse(RewriterVisitor, { functor, module: moduleFunctionRegistry} as IRewriterVisitorState);
+}

--- a/test/function-extractor/imports-registry.specs.ts
+++ b/test/function-extractor/imports-registry.specs.ts
@@ -1,0 +1,99 @@
+import {expect} from "chai";
+import * as t from "babel-types";
+import {ImportsRegistry} from "../../src/function-extractor/imports-registry";
+import {NodePath} from "babel-traverse";
+import {toPath} from "../test-utils";
+
+describe("ImportsRegistry", function () {
+    let registry: ImportsRegistry;
+    let functor: NodePath<t.Function>;
+
+    beforeEach(function () {
+        registry = new ImportsRegistry();
+        functor = toPath(t.functionDeclaration(t.identifier("test"), [], t.blockStatement([])));
+    });
+
+    describe("addImport", function () {
+        it("adds the named import", function () {
+            // act
+            registry.addImport("lodash", "map", "lodashMap", functor);
+
+            // assert
+            const imports = registry.getImports();
+            expect(imports).to.have.property("lodash");
+            expect(imports).to.have.property("lodash").that.eql([{ imported: "map", local: "lodashMap", references: [functor] }]);
+        });
+
+        it("merges equal imports", function () {
+            // arrange
+            registry.addImport("lodash", "map", "lodashMap", functor);
+            const secondFunctor = toPath(t.functionDeclaration(t.identifier("test"), [], t.blockStatement([])));
+
+            // act
+            registry.addImport("lodash", "map", "lodashMap", secondFunctor);
+
+            // assert
+            const imports = registry.getImports();
+            expect(imports).to.have.property("lodash");
+            expect(imports).to.have.property("lodash").that.eql([{ imported: "map", local: "lodashMap", references: [functor, secondFunctor] }]);
+        });
+
+        it("distinguishes between different imports", function() {
+            // arrange
+            registry.addImport("lodash", "map", "lodashMap", functor);
+
+            // act
+            registry.addImport("lodash", "filter", "filter", functor);
+
+            // assert
+            const imports = registry.getImports();
+            expect(imports).to.have.property("lodash");
+            expect(imports).to.have.property("lodash").that.eql([
+                { imported: "map", local: "lodashMap", references: [functor] },
+                { imported: "filter", local: "filter", references: [functor] }
+            ]);
+        });
+
+        it("distinguishes imports of different modules", function () {
+            // arrange
+            registry.addImport("lodash", "map", "lodashMap", functor);
+
+            // act
+            registry.addImport("underscore", "filter", "filter", functor);
+
+            // assert
+            const imports = registry.getImports();
+            expect(imports).to.have.property("lodash");
+            expect(imports).to.have.property("lodash").that.eql([
+                { imported: "map", local: "lodashMap", references: [functor] }
+            ]);
+            expect(imports).to.have.property("underscore").that.eql([
+                { imported: "filter", local: "filter", references: [functor] }
+            ]);
+        });
+    });
+
+    describe("addDefaultImport", function () {
+        it("adds an import for default", function () {
+            // act
+            registry.addDefaultImport("lodash", "_", functor);
+
+            // assert
+            const imports = registry.getImports();
+            expect(imports).to.have.property("lodash");
+            expect(imports).to.have.property("lodash").that.eql([{ imported: "default", local: "_", references: [functor] }]);
+        });
+    });
+
+    describe("addNamespaceImport", function () {
+        it("adds an import for the defined namespace", function () {
+            // act
+            registry.addImport("lodash", "*", "_", functor);
+
+            // assert
+            const imports = registry.getImports();
+            expect(imports).to.have.property("lodash");
+            expect(imports).to.have.property("lodash").that.eql([{ imported: "*", local: "_", references: [functor] }]);
+        });
+    });
+});

--- a/test/function-extractor/module-function-registry.specs.ts
+++ b/test/function-extractor/module-function-registry.specs.ts
@@ -1,7 +1,7 @@
 import {expect} from "chai";
 import * as t from "babel-types";
 import {ModuleFunctionsRegistry} from "../../src/function-extractor/module-functions-registry";
-import traverse, {NodePath} from "babel-traverse";
+import {toPath} from "../test-utils";
 
 describe("ModuleFunctionRegistry", function () {
 
@@ -145,15 +145,4 @@ describe("ModuleFunctionRegistry", function () {
             expect(registry.empty).to.be.false;
         });
     });
-
-    function toPath<T extends t.Statement>(node: T): NodePath<T> {
-        let result: NodePath<T> | undefined = undefined;
-        traverse(t.file(t.program([node])), {
-            Statement(path: NodePath<t.Statement>) {
-                result = path as NodePath<T>;
-                path.skip();
-            }
-        });
-        return result!;
-    }
 });

--- a/test/function-extractor/transpile-functor.specs.ts
+++ b/test/function-extractor/transpile-functor.specs.ts
@@ -1,0 +1,74 @@
+import * as sinon from "sinon";
+import {expect, use} from "chai";
+import * as sinonChai from "sinon-chai";
+import * as t from "babel-types";
+import {NodePath} from "babel-traverse";
+import {transpileFunctor} from "../../src/function-extractor/transpile-functor";
+import {ModuleFunctionsRegistry} from "../../src/function-extractor/module-functions-registry";
+import {toPath} from "../test-utils";
+
+use(sinonChai);
+
+describe("TranspileFunctors", function () {
+
+    let registry: ModuleFunctionsRegistry;
+
+    beforeEach(function () {
+        registry = new ModuleFunctionsRegistry("test.js");
+    });
+
+    describe("Imports", function () {
+        it("registers namespace imports", function () {
+            // arrange
+            const addNamespaceSpy = sinon.spy(registry.imports, "addNamespaceImport");
+            const program = toPath(`
+            import * as _ from "lodash";
+            function test() {
+                _.map([1, 2, 3], value => value * 2);
+            }`);
+            const functor = program.get("body.1") as NodePath<t.Function>;
+
+            // act
+            transpileFunctor(functor, registry);
+
+            // assert
+            expect(addNamespaceSpy).to.have.been.calledWith("lodash", "_", functor);
+        });
+
+        it("registers default imports", function () {
+            // arrange
+            const addDefaultImportSpy = sinon.spy(registry.imports, "addDefaultImport");
+            const program = toPath(`
+            import traverse from "babel-traverse";
+            function t(ast) {
+                traverse(ast);
+            }
+            `);
+            const functor = program.get("body.1") as NodePath<t.Function>;
+
+            // act
+            transpileFunctor(functor, registry);
+
+            // assert
+            expect(addDefaultImportSpy).to.have.been.calledWith("babel-traverse", "traverse", functor);
+        });
+
+        it("registers named import", function () {
+            // arrange
+            const addImportSpy = sinon.spy(registry.imports, "addImport");
+            const program = toPath(`
+            import {map} from "lodash";
+            function t(ast) {
+                map([1, 2, 3], value => value * 2);
+            }
+            `);
+            const functor = program.get("body.1") as NodePath<t.Function>;
+
+            // act
+            transpileFunctor(functor, registry);
+
+            // assert
+            expect(addImportSpy).to.have.been.calledWith("lodash", "map", "map", functor);
+        });
+    });
+});

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -1,0 +1,54 @@
+import * as t from "babel-types";
+import {parse} from "babylon";
+import {NodePath} from "babel-traverse";
+import {transformFromAst} from "babel-core";
+
+/**
+ * Returns the node path for the program node of the given code
+ * @param code the code for which the path should be retrieved
+ */
+export function toPath(code: string): NodePath<t.Program>;
+
+/**
+ * Returns the path for the given node
+ * @param node the node for which the path is to be retrieved
+ */
+export function toPath<T extends t.Expression | t.Statement>(node: T): NodePath<T>;
+
+export function toPath(node: t.Node | string): NodePath<t.Node> {
+    let root: t.Node;
+    if (typeof node === "string") {
+        root = parse(node, { sourceType: "module" });
+    } else {
+        let statement: t.Statement;
+        if (t.isStatement(node)) {
+            statement = node;
+        } else {
+            statement = t.expressionStatement(node as t.Expression);
+        }
+        root = t.file(t.program([statement]));
+    }
+
+    let nodePath: NodePath<t.Node> | undefined = undefined;
+
+    transformFromAst(root, undefined, {
+        plugins: [{
+            visitor: {
+                Program(path: NodePath<t.Program>) {
+                    if (typeof node === "string") {
+                        nodePath = path;
+                    } else {
+                        const statementPath = path.get("body.0");
+                        if (t.isStatement(node)) {
+                            nodePath = statementPath;
+                        } else {
+                            nodePath = statementPath.get("expression");
+                        }
+                    }
+                }
+            }
+        }]
+    });
+
+    return nodePath!;
+}


### PR DESCRIPTION
A functor can access imports from ES6 Modules. The Transpiler needs to identify the used imports and add them as dependency to the worker-slave.js.
As the same module might have been imported by different modules using different names, the module names need to be unified after adding the import
