### PR TITLE
Traverse Program in exit

### DIFF
--- a/src/function-extractor/function-extractor-plugin.ts
+++ b/src/function-extractor/function-extractor-plugin.ts
@@ -11,6 +11,8 @@ export default function FunctionExtractorPlugin(): IBabelPlugin {
             parserOptions.sourceFilename = options.filename;
         },
 
+        inherits: require("babel-plugin-undeclared-variables-check"),
+
         visitor: ParallelFunctorsExtractorVisitor(SHARED_MODULES_USING_PARALLEL_REGISTRY)
     };
 }


### PR DESCRIPTION
This ensures that all other plugins could traverse the program first before the functions are extracted.
Makes enabling of the babel-plugin-undeclared-variables-check easier.